### PR TITLE
Update: decrypt with multiple CPU cores

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -1,12 +1,44 @@
 import os
 import sys
 import hashlib
+import multiprocessing
+import os
+
 
 def xor_bytes(data, key):
     return bytes(a ^ b for a, b in zip(data, (key * (len(data) // len(key) + 1))[:len(data)]))
 
+def xor_worker(task_queue, result_queue):
+    while True:
+        chunk_idx, data, key = task_queue.get()
+        result_queue.put((chunk_idx, xor_bytes(data, key)))
+        task_queue.task_done()
+
+def write_result_chunk(fp, w_chunk_idx, pending, hasher):
+    if not pending:
+        return w_chunk_idx, pending
+    pending.sort()
+    for pending_idx, (chunk_idx, chunk) in enumerate(pending):
+        if chunk_idx != w_chunk_idx:
+            return w_chunk_idx, pending[pending_idx:]
+        fp.write(chunk)
+        hasher.update(chunk)
+        w_chunk_idx += 1
+    return w_chunk_idx, []
+
 def main(input_file, key_file, output_dir):
-    print("Decrypting file " + input_file)
+    worker_count = max(1, os.cpu_count() - 1)
+    print(f"Decrypting file {input_file} with {worker_count} workers")
+
+    task_queue = multiprocessing.JoinableQueue(worker_count * 3)
+    result_queue = multiprocessing.Queue()
+    processes = [
+        multiprocessing.Process(target=xor_worker, args=(task_queue, result_queue))
+        for _ in range(worker_count)
+    ]
+    for p in processes:
+        p.daemon = True
+        p.start()
 
     chunk_size = 10 * 1024 * 1024
     key_chunk_size = 10 * 1024 * 1024
@@ -33,6 +65,10 @@ def main(input_file, key_file, output_dir):
         output_file = os.path.join(output_dir, input_file_basename)
 
         with open(output_file, "wb") as out_file:
+            r_chunk_idx = 0  # how many chunks we have read
+            w_chunk_idx = 0  # how many chunks have been written
+            write_pending = []  # have xor results, awaiting to be written to file
+
             bytes_read = 0
             while True:
                 chunk = in_file.read(chunk_size)
@@ -43,24 +79,31 @@ def main(input_file, key_file, output_dir):
                 if not key_chunk:
                     key_file.seek(0)
                     key_chunk = key_file.read(key_chunk_size)
+                
+                task_queue.put((r_chunk_idx, chunk, key_chunk))
+                # read available results
+                while not result_queue.empty():
+                    write_pending.append(result_queue.get())
+                    
+                w_chunk_idx_new, write_pending = write_result_chunk(out_file, w_chunk_idx, write_pending, hasher)
 
-                decrypted_chunk = xor_bytes(chunk, key_chunk)
-                out_file.write(decrypted_chunk)
-
-                bytes_read += len(chunk)
+                bytes_read += (w_chunk_idx_new - w_chunk_idx) * chunk_size
                 progress = bytes_read / file_size * 100
                 sys.stdout.write(f"\rProgress: {progress:.2f}%")
                 sys.stdout.flush()
+                
+                w_chunk_idx = w_chunk_idx_new
+                r_chunk_idx += 1
 
-        with open(output_file, "rb") as out_file:
-            # Compute the checksum over the decrypted file
-            out_file.seek(0)
-            while True:
-                chunk = out_file.read(chunk_size)
-                if not chunk:
-                    break
-
-                hasher.update(chunk)
+            # wait for xor workers
+            sys.stdout.write('\rWaiting for workers...')
+            sys.stdout.flush()
+            task_queue.join()
+            while not result_queue.empty():
+                write_pending.append(result_queue.get())
+            sys.stdout.write('\rWriting final chunks...')
+            sys.stdout.flush()
+            write_result_chunk(out_file, w_chunk_idx, write_pending, hasher)
 
             computed_hash = hasher.digest()
 


### PR DESCRIPTION
Decrypt with `os.cpu_count() - 1` processes, and update `hasher` when writing result chunks to file. This should significantly speedup decryption on multi-core CPUs.